### PR TITLE
Fix ListRecords throwing QueryException when backslashes were used

### DIFF
--- a/src/OaiPmh/ResponseGenerator.php
+++ b/src/OaiPmh/ResponseGenerator.php
@@ -622,8 +622,8 @@ class ResponseGenerator extends AbstractXmlGenerator
         $entityManager = $this->serviceLocator->get('Omeka\EntityManager');
 
         $itemRepository = $entityManager->getRepository('Omeka\Entity\Item');
-        $qb = $itemRepository->createQueryBuilder('Omeka\Entity\Item');
-        $qb->select('Omeka\Entity\Item');
+        $qb = $itemRepository->createQueryBuilder('Item');
+        $qb->select('Item');
 
         $query = new ArrayObject;
 
@@ -667,12 +667,12 @@ class ResponseGenerator extends AbstractXmlGenerator
         if ($from) {
             $qb->andWhere($qb->expr()->orX(
                 $qb->expr()->andX(
-                    $qb->expr()->isNotNull('Omeka\Entity\Item.modified'),
-                    $qb->expr()->gte('Omeka\Entity\Item.modified', ':from_1')
+                    $qb->expr()->isNotNull('Item.modified'),
+                    $qb->expr()->gte('Item.modified', ':from_1')
                 ),
                 $qb->expr()->andX(
-                    $qb->expr()->isNull('Omeka\Entity\Item.modified'),
-                    $qb->expr()->gte('Omeka\Entity\Item.created', ':from_2')
+                    $qb->expr()->isNull('Item.modified'),
+                    $qb->expr()->gte('Item.created', ':from_2')
                 )
             ));
             $qb->setParameter('from_1', $from);
@@ -681,19 +681,19 @@ class ResponseGenerator extends AbstractXmlGenerator
         if ($until) {
             $qb->andWhere($qb->expr()->orX(
                 $qb->expr()->andX(
-                    $qb->expr()->isNotNull('Omeka\Entity\Item.modified'),
-                    $qb->expr()->lte('Omeka\Entity\Item.modified', ':until_1')
+                    $qb->expr()->isNotNull('Item.modified'),
+                    $qb->expr()->lte('Item.modified', ':until_1')
                 ),
                 $qb->expr()->andX(
-                    $qb->expr()->isNull('Omeka\Entity\Item.modified'),
-                    $qb->expr()->lte('Omeka\Entity\Item.created', ':until_2')
+                    $qb->expr()->isNull('Item.modified'),
+                    $qb->expr()->lte('Item.created', ':until_2')
                 )
             ));
             $qb->setParameter('until_1', $until);
             $qb->setParameter('until_2', $until);
         }
 
-        $qb->groupBy('Omeka\Entity\Item.id');
+        $qb->groupBy('Item.id');
 
         // This limit call will form the basis of the flow control
         $qb->setMaxResults($this->_listLimit);


### PR DESCRIPTION
Hello,

In our Omeka S 2.x installation, there was an error shown when trying to query the OAI API. We tested the module also in Omeka S 1.4 unsuccessfully. We applied this small patch and now the API is working as expected. We think it was related to the QueryBuilder "Omeka\Entity\Item" alias having backslashes. This commit approaches the following exception:

Doctrine\ORM\Query\QueryException
[Syntax Error] line 0, col 35: Error: Expected Doctrine\ORM\Query\Lexer::T_IDENTIFIER, got 'Omeka\Entity\Item'

Doctrine\ORM\Query\QueryException: SELECT Item FROM Omeka\Entity\Item Omeka\Entity\Item GROUP BY Item.id in /var/www/html/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:43

Regards,
Álvaro Galdón
(Collaborator at Libnamic)