### PR TITLE
Fix an issue when trying to limit results to a specific set.

### DIFF
--- a/src/OaiPmh/ResponseGenerator.php
+++ b/src/OaiPmh/ResponseGenerator.php
@@ -667,12 +667,12 @@ class ResponseGenerator extends AbstractXmlGenerator
         if ($from) {
             $qb->andWhere($qb->expr()->orX(
                 $qb->expr()->andX(
-                    $qb->expr()->isNotNull('Item.modified'),
-                    $qb->expr()->gte('Item.modified', ':from_1')
+                    $qb->expr()->isNotNull('omeka_root.modified'),
+                    $qb->expr()->gte('omeka_root.modified', ':from_1')
                 ),
                 $qb->expr()->andX(
-                    $qb->expr()->isNull('Item.modified'),
-                    $qb->expr()->gte('Item.created', ':from_2')
+                    $qb->expr()->isNull('omeka_root.modified'),
+                    $qb->expr()->gte('omeka_root.created', ':from_2')
                 )
             ));
             $qb->setParameter('from_1', $from);
@@ -681,12 +681,12 @@ class ResponseGenerator extends AbstractXmlGenerator
         if ($until) {
             $qb->andWhere($qb->expr()->orX(
                 $qb->expr()->andX(
-                    $qb->expr()->isNotNull('Omeka\Entity\Item.modified'),
-                    $qb->expr()->lte('Item.modified', ':until_1')
+                    $qb->expr()->isNotNull('omeka_root.modified'),
+                    $qb->expr()->lte('omeka_root.modified', ':until_1')
                 ),
                 $qb->expr()->andX(
-                    $qb->expr()->isNull('Omeka\Entity\Item.modified'),
-                    $qb->expr()->lte('Item.created', ':until_2')
+                    $qb->expr()->isNull('omeka_root.modified'),
+                    $qb->expr()->lte('omeka_root.created', ':until_2')
                 )
             ));
             $qb->setParameter('until_1', $until);

--- a/src/OaiPmh/ResponseGenerator.php
+++ b/src/OaiPmh/ResponseGenerator.php
@@ -622,8 +622,8 @@ class ResponseGenerator extends AbstractXmlGenerator
         $entityManager = $this->serviceLocator->get('Omeka\EntityManager');
 
         $itemRepository = $entityManager->getRepository('Omeka\Entity\Item');
-        $qb = $itemRepository->createQueryBuilder('Item');
-        $qb->select('Item');
+        $qb = $itemRepository->createQueryBuilder('omeka_root');
+        $qb->select('omeka_root');
 
         $query = new ArrayObject;
 
@@ -693,7 +693,7 @@ class ResponseGenerator extends AbstractXmlGenerator
             $qb->setParameter('until_2', $until);
         }
 
-        $qb->groupBy('Item.id');
+        $qb->groupBy('omeka_root.id');
 
         // This limit call will form the basis of the flow control
         $qb->setMaxResults($this->_listLimit);


### PR DESCRIPTION
With the current version, as soon as you try to limit to a specific set there is an error, because omeka tries to run an innerJoin on omeka_root, but no omeka_root is defined. 

This patch aims at fixing that. I have tried different options (ListIdentifier, ListRecords ...) and it does not seem to break anything.